### PR TITLE
update: Project id can be used to fetch project db document

### DIFF
--- a/statusdb/db/__init__.py
+++ b/statusdb/db/__init__.py
@@ -44,7 +44,7 @@ class Couch(Database):
     _update_fn = None
 
     def __init__(self, log=None, url=None,conf=None, **kwargs):
-        
+
         # Load from config if we have one
         config = statusdb_config.load_config(conf)
         try:
@@ -61,7 +61,7 @@ class Couch(Database):
                 raise KeyError("The configuration file is missing an essential key, either 'url', 'port', 'username', or 'password'")
             self.db= config['statusdb'].get('db')
 
-        
+
         # Overwrite with command line options if we have them
         if 'username' in kwargs:
             self.user = kwargs['username']
@@ -73,13 +73,13 @@ class Couch(Database):
             self.db = kwargs['db']
         if 'url' in kwargs:
             self.url = kwargs['url']
-        
+
         # Connect to the database
         self.url_string = "http://{}:{}@{}:{}".format(self.user, self.pw, self.url, self.port)
         self.display_url_string = "http://{}:{}@{}:{}".format(self.user, "*********", self.url, self.port)
         if log:
             self.log = log
-        super(Couch, self).__init__(**kwargs)        
+        super(Couch, self).__init__(**kwargs)
         if not self.con:
             raise ConnectionError("Connection failed for url {}".format(self.display_url_string))
 
@@ -100,7 +100,7 @@ class Couch(Database):
         except:
             return None
 
-    def get_entry(self, name, field=None):
+    def get_entry(self, name, field=None, use_id_view=False):
         """Retrieve entry from db for a given name, subset to field if
         that value is passed.
 
@@ -113,7 +113,10 @@ class Couch(Database):
         if self.name_view.get(name, None) is None:
             self.log.warn("no entry '{}' in {}".format(name, self.db))
             return None
-        doc = self._doc_type(**self.db.get(self.name_view.get(name)))
+        if use_id_view:
+            doc = self._doc_type(**self.db.get(self.id_view.get(name)))
+        else:
+            doc = self._doc_type(**self.db.get(self.name_view.get(name)))
         if field:
             return doc[field]
         else:

--- a/statusdb/db/__init__.py
+++ b/statusdb/db/__init__.py
@@ -110,13 +110,14 @@ class Couch(Database):
         if not self._doc_type:
             return
         self.log.debug("retrieving field entry in field '{}' for name '{}'".format(field, name))
-        if self.name_view.get(name, None) is None:
+        if use_id_view:
+            view = self.id_view
+        else:
+            view = self.name_view
+        if view.get(name, None) is None:
             self.log.warn("no entry '{}' in {}".format(name, self.db))
             return None
-        if use_id_view:
-            doc = self._doc_type(**self.db.get(self.id_view.get(name)))
-        else:
-            doc = self._doc_type(**self.db.get(self.name_view.get(name)))
+        doc = self._doc_type(**self.db.get(view.get(name)))
         if field:
             return doc[field]
         else:

--- a/statusdb/db/__init__.py
+++ b/statusdb/db/__init__.py
@@ -106,6 +106,7 @@ class Couch(Database):
 
         :param name: unique name identifier (primary key, not the uuid)
         :param field: get 'field' of document, i.e. key in document dict
+        :param use_id_view: Boolean to mention which view to use (name or id)
         """
         if not self._doc_type:
             return

--- a/statusdb/db/connections.py
+++ b/statusdb/db/connections.py
@@ -300,20 +300,20 @@ class SampleRunMetricsConnection(Couch):
         inv_view = {v:k for k,v in self.name_view.iteritems()}
         sample_names = [inv_view[x] for x in sample_ids]
         return [self.get_entry(x) for x in sample_names]
-    
+
     def get_project_sample(self, prj_sample_name, sample_prj=None, fc_id=None):
         """Retrieve all documents for a project sample based on the project_sample_name field,
         possibly subset by sample_prj and fc_id
-        
+
         :param prj_sample_name: project sample name
         :param sample_prj: Name of the project
         :param fc_id: Flowcell id
-        
+
         :returns samples: list of sample_run_metrics documents
         """
-        
+
         return [s for s in self.get_samples(fc_id,sample_prj) if s.get("project_sample_name","") == prj_sample_name]
-        
+
 class FlowcellRunMetricsConnection(Couch):
     _doc_type = FlowcellRunMetricsDocument
     _update_fn = update_fn
@@ -426,6 +426,7 @@ class ProjectSummaryConnection(Couch):
         super(ProjectSummaryConnection, self).__init__(**kwargs)
         self.db = self.con[dbname]
         self.name_view = {k.key:k.id for k in self.db.view("project/project_name", reduce=False)}
+        self.id_view = {k.key:k.id for k in self.db.view("project/project_id", reduce=False)}
 
     def set_db(self, dbname):
         """Make sure we don't change db from projects"""


### PR DESCRIPTION
Currently `get_entry` uses only name view to fetch the database document. But for IGN sample report is would be easier if the document can be fetched using project id. 